### PR TITLE
Update module to lookup certs by name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM hashicorp/terraform
+
+RUN apk add make
+
+WORKDIR /tmp
+COPY . /tmp
+
+ENTRYPOINT [ "/usr/bin/make" ]

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,51 @@
-.PHONY: test clean
+.PHONY: test clean docker sh shell
+
+REPO := $(shell basename $(shell git remote get-url origin) .git)
 
 test: .terraform
 	AWS_DEFAULT_REGION=us-east-2 terraform validate
 	terraform fmt -check
-	! grep -l TF-UPGRADE-TODO *.tf
-	# Check for badge in README.md
-	grep -q "\[\!\[Build Status\]([^)]*)\]([^)]*)" README.md
+	! egrep "TF-UPGRADE-TODO|cites-illinois|as-aws-modules" *.tf README.md
+	# Do NOT put terraform-aws in the title
+	! grep "#\s*terraform-aws-" README.md
+	# Do NOT use type string when you can use type number or bool!
+	! egrep '"\d+"|"true"|"false"' *.tf README.md
+	# Do NOT use old style maps in docs
+	! egrep "\w+\s*\{" README.md
+	# Do NOT drop the "s" in outputs.tf or variables.tf!
+	! find . -name output.tf -o -name variable.tf | grep '.*'
+	# Do NOT define an output in files other than outputs.tf
+	! egrep 'output\s+"\w+"\s*\{' $(shell find . -name '*.tf' ! -name outputs.tf)
+	# Do NOT define a variable in files other than variables.tf
+	! egrep 'variable\s+"\w+"\s*\{' $(shell find . -name '*.tf' ! -name variables.tf)
+	# DO put a badge in README.md
+	grep -q "\[\!\[Build Status\]([^)]*$(REPO)/status.svg)\]([^)]*$(REPO))" README.md
+	# Do NOT use ?ref= in source lines in a README.md!
+	! grep 'source\s*=.*?ref=' *.tf README.md
+	# Do NOT start a source line with git::
+	! grep 'source\s*=\s*"git::' *.tf README.md
+	# Do NOT use .git in a source line
+	! grep 'source\s*=.*\.git.*"' *.tf README.md
+
+# Launches the Makefile inside a container
+docker: 
+	docker build . -t test/$(REPO)
+	docker run --rm test/$(REPO)
+
+# Create alias
+sh: shell
+
+# Launches the shell inside a container for debugging the Makefile
+shell:
+	docker build . -t test/$(REPO)
+	docker run -it --rm --entrypoint=sh test/$(REPO)
 
 clean:
-	rm -rf .terraform
+	-rm -rf .terraform
+	-docker rmi test/$(REPO)
 
+# Create .terraform if does not exist
+# A terraform init is requried to run a validate :-(
 .terraform:
 	terraform init -backend=false
 	terraform version

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ module "foo" {
   name = "distributionName"
   aliases = [ "alias1", "alias2", ... "aliasN" ]
   bucket = "bucketName"
-  certificate_arn = "certificateARN" 
   hostname = "virtualHostname"
   origin_access_identity_path" = "oaiPath"
 }
@@ -28,8 +27,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the repository.
 * `aliases` - Aliases (hostnames handled by the distribution).
 * `bucket` - (Required) S3 bucket used for CloudFront origin.
-* `certificate_arn` - (Required for HTTP distributions) ARN of the AWS Certificate Manager certificate for distribution.
-* `enable` - Allow the distribution to accept requests. (Defaults to "true".)
+* `enable` - Allow the distribution to accept requests. (Defaults to true.)
 * `hostname` - (Required) Logical hostname; used to derive prefix within S3 bucket.
 * `cloudfront_lambda_origin_request_arn` - (Required) ARN of Lambda@Edge function to be run for origin request.
 * `log_bucket` - Log bucket. **NOTE**: This is not required, as the built-in default is suitable in most cases.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
+output "cert_arn" {
+  value = data.aws_acm_certificate.selected.arn
+}
+
 output "cloudfront_domain_name" {
   value = aws_cloudfront_distribution.default.domain_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,10 +6,7 @@ variable "aliases" {
 
 variable "bucket" {
   description = "S3 bucket used for this CloudFront origin"
-}
-
-variable "certificate_arn" {
-  description = "ARN of the AWS Certificate Manager certificate for distribution"
+  default     = ""
 }
 
 variable "enabled" {


### PR DESCRIPTION
Update the module to lookup certificates using a [data source](https://www.terraform.io/docs/providers/aws/d/acm_certificate.html) by name instead of ARN.

See: https://trello.com/c/wdgjNXHt