### PR TITLE
Allow hostname to be empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: .terraform
 	! grep 'source\s*=.*\.git.*"' *.tf README.md
 
 # Launches the Makefile inside a container
-docker: 
+docker:
 	docker build . -t test/$(REPO)
 	docker run --rm test/$(REPO)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ are created in the zone determined by the user supplied domain.
 Example Usage
 -----------------
 
+### www.foo.com in zone foo.com
+
 ```hcl
 module "foo" {
   source = "git@github.com:techservicesillinois/terraform-aws-cloudfront-distribution"
@@ -29,12 +31,26 @@ module "foo" {
   cloudfront_lambda_origin_request_arn = "arn:aws:lambda:us-east-1:617683844790:function:cloudfront-directory-index:1"
 ```
 
+### www.foo.com in zone www.foo.com
+
+```hcl
+module "foo" {
+  source = "git@github.com:techservicesillinois/terraform-aws-cloudfront-distribution"
+
+  domain = "www.foo.com"
+
+  bucket = "some-S3-bucket"
+  origin_access_identity_path = "origin-access-identity/cloudfront/QA0DOUCO4WRZ2"
+
+  cloudfront_lambda_origin_request_arn = "arn:aws:lambda:us-east-1:617683844790:function:cloudfront-directory-index:1"
+```
+
 Argument Reference
 -----------------
 
 The following arguments are supported:
 
-* `hostname` - (Required) The primary hostname used in the S3 prefix, to create a Route 53 record, and ACM certificate.
+* `hostname` - (Optional) The primary hostname used in the S3 prefix, to create a Route 53 record, and ACM certificate.
 * `domain` - (Required) The primary domain used in the S3 prefix, to create a Route 53 record, and ACM certificate.
 * `bucket` - (Required) S3 bucket used as the CloudFront origin.
 * `origin_access_identity_path` - (Required) CloudFront origin access identity for the S3 bucket.

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   bucket_name        = data.aws_s3_bucket.selected.id
   bucket_origin_id   = "S3-${data.aws_s3_bucket.selected.id}"
   default_log_bucket = "log-${data.aws_region.current.name}-${data.aws_caller_identity.current.account_id}"
-  fqdn               = "${var.hostname}.${var.domain}"
+  fqdn               = length(var.hostname) > 0 ? "${var.hostname}.${var.domain}" : "${var.domain}"
 
   # User can override log bucket name.
   log_bucket                  = var.log_bucket != "" ? var.log_bucket : local.default_log_bucket

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,7 @@
 
 variable "hostname" {
   description = "The primary hostname used in the S3 prefix, to create Route 53 records, and ACM certificates."
+  default     = ""
 }
 
 variable "domain" {


### PR DESCRIPTION
To create a CloudFront distribution for the top-level of a zone it
is necessary for the hostname to be empty. This commit allows support
for this use case.