### PR TITLE
Add dynamodb_table_name to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The following attributes are exported:
 
 * `cert_arn` - ACM certificate attached to the CloudFront distribution.
 * `cloudfront_domain_name` - Full domain name of CloudFront distribution.
+* `dynamodb_table_name` - Name of the DynamoDB table holding credentials for HTTP basic authentication.
 * `log_bucket` - Name of log bucket used for distribution.
 * `s3_prefix` - Prefix of this distribution within the origin S3 bucket.
 

--- a/basic-auth/outputs.tf
+++ b/basic-auth/outputs.tf
@@ -1,3 +1,7 @@
 output "policy_arn" {
   value = length(var.regions) > 0 && var.policy_name != "" ? aws_iam_policy.default[0].arn : null
 }
+
+output "dynamodb_table" {
+  value = length(var.regions) > 0 ? aws_dynamodb_global_table.default : null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,8 @@ output "policy_arn" {
   description = "DynamoDB admin policy ARN"
   value       = module.basic-auth.policy_arn
 }
+
+output "dynamodb_table_name" {
+  description = "DynamoDB table name"
+  value       = module.basic-auth.dynamodb_table[0].name
+}


### PR DESCRIPTION
Our customers find it more difficult to find the DynamoDB table name than it ought to be, and I agree. Hence this PR adding that variable. The submodule outputs the whole `aws_dynamodb_global_table.default` object so that the calling module can choose what it needs from that object.