### PR TITLE
Fix error in certificate handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform
+FROM hashicorp/terraform:0.12.31
 
 RUN apk add make
 

--- a/acm.tf
+++ b/acm.tf
@@ -29,7 +29,7 @@ resource "aws_acm_certificate" "default" {
 
 resource "aws_route53_record" "acm" {
   for_each = {
-    for dvo in aws_acm_certificate.default[0].domain_validation_options : dvo.domain_name => {
+    for dvo in(local.create_acm_cert ? aws_acm_certificate.default[0].domain_validation_options : {}) : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,8 @@
 # Get S3 prefix for CloudFront distribution.
 
 module "s3-prefix" {
-  source = "git@github.com:techservicesillinois/terraform-aws-util//modules/compute-s3-prefix?ref=v3.0.0"
+  # NOTE: Use canonical GitHub URL to make GitHub Actions happy.
+  source = "github.com/techservicesillinois/terraform-aws-util//modules/compute-s3-prefix?ref=v3.0.2"
 
   fqdn = local.fqdn
 }


### PR DESCRIPTION
Fixed code that fails with the AWS v3 provider for infrastructure definitions meeting the following conditions:

```
inputs = {
  ...
  create_route53_record = false
  create_acm_cert       = false
}
```

The problem was a `for_each` expression that didn't allow for this particular combination of inputs. This use case didn't exist in the test account, and hence wasn't detected during provider upgrade there.