### PR TITLE
Fix bug with toset() needing an empty list

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,9 +20,9 @@ jobs:
 
       - name: terraform setup
         uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: 0.12.29
-      #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+      # with:
+      #   terraform_version: 0.12.29
+      ##    cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
 #     TODO: This step duplicates work done by the Makefile.
 #     - name: check terraform formatting

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: tfc test
 tfc: .terraform
 	@# Basic Terraform validation and formating checks
 	terraform version
-	AWS_DEFAULT_REGION=us-east-2 terraform validate
+	terraform validate
 	terraform fmt -check -recursive
 
 # Create .terraform if does not exist

--- a/acm.tf
+++ b/acm.tf
@@ -29,7 +29,7 @@ resource "aws_acm_certificate" "default" {
 
 resource "aws_route53_record" "acm" {
   for_each = {
-    for dvo in (local.create_acm_cert ? aws_acm_certificate.default[0].domain_validation_options : toset()) : dvo.domain_name => {
+    for dvo in(local.create_acm_cert ? aws_acm_certificate.default[0].domain_validation_options : toset([])) : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type


### PR DESCRIPTION
Fixed syntax error relating to `toset()` in Terraform configuration.