### PR TITLE
v3.5.0 broke a few use cases

### DIFF
--- a/basic-auth/main.tf
+++ b/basic-auth/main.tf
@@ -9,6 +9,7 @@ locals {
 }
 
 resource "aws_dynamodb_table" "default" {
+  count            = (length(var.regions) != 0) ? 1 : 0
   name             = var.name
   hash_key         = "username"
   billing_mode     = "PAY_PER_REQUEST"

--- a/basic-auth/policy.tf
+++ b/basic-auth/policy.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "default" {
       "dynamodb:UpdateItem",
     ]
 
-    resources = ["arn:aws:dynamodb:${local.region}:${local.account_id}:table/${aws_dynamodb_table.default.name}"]
+    resources = ["arn:aws:dynamodb:${local.region}:${local.account_id}:table/${aws_dynamodb_table.default[0].name}"]
   }
 }
 
@@ -26,7 +26,7 @@ resource "aws_iam_policy" "default" {
   name = var.policy_name
   path = "/"
 
-  description = "Policy for DynamoDB table ${aws_dynamodb_table.default.name}"
+  description = "Policy for DynamoDB table ${aws_dynamodb_table.default[0].name}"
 
   policy = data.aws_iam_policy_document.default[0].json
 }

--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -1,6 +1,7 @@
 module "basic-auth" {
   source = "./basic-auth"
 
+  count       = (length(var.basic_auth) == 0) ? 0 : 1
   name        = format("CloudFront-Basic-Auth-%s", aws_cloudfront_distribution.default.id)
   regions     = lookup(var.basic_auth, "regions", [])
   policy_name = lookup(var.basic_auth, "policy_name", "")

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,18 +25,24 @@ output "s3_prefix" {
 
 output "policy_arn" {
   description = "DynamoDB admin policy ARN"
-  value       = module.basic-auth.policy_arn
+  value       = (length(var.basic_auth) > 0) ? module.basic-auth[0].policy_arn : null
 }
 
 output "dynamodb_table_name" {
   description = "DynamoDB table name"
-  value       = module.basic-auth.dynamodb_table.name != null ? module.basic-auth.dynamodb_table.name : null
+  value       = (length(var.basic_auth) > 0) ? module.basic-auth[0].dynamodb_table[0].name : null
 }
 
-#output "regions" {
-#  value = module.basic-auth.regions
-# }
-#
+# Debug output.
+
+#output "known_regions" {
+# description = "Regions that are available and opted-in"
+# value       = (length(var.basic_auth) > 0) ? module.basic-auth[0].known_regions : null
+#}
+
+# Debug output.
+
 #output "replica_regions" {
-# value = module.basic-auth.replica_regions
+# description = "Regions in which DynamoDB replicas are deployed"
+# value       = (length(var.basic_auth) > 0) ? module.basic-auth[0].replica_regions : null
 #}


### PR DESCRIPTION
CloudFront distributions not using HTTP basic authentication were broken by the v3.5.0 release. Fixed by invoking basic-auth submodule conditionally, which also required changing some variable references in outputs.